### PR TITLE
Point "Conversations" link to right place

### DIFF
--- a/index.md
+++ b/index.md
@@ -117,7 +117,7 @@ title: Codemania 2017 - New Zealand's Premier Software Conference
       <div class="about-text-container">
         <div class="about-text-column">
           <p>Codemania is back and better than ever: a full day of information and inspiration from software practitioners at the top of their game. <a href="/agenda.html" class="hilite">Codemania conference</a> will be held at the luxurious Langham Hotel on Friday April 28th.</p>
-          <p>Once again, you can also join our world-class speakers and an exclusive gathering of your Codemania family for the whole weekend after Codemania conference. <a href="/conversations.html" class="hilite">Codemania conversations</a> returns to the Waitakere Estate, deep in the heart of one of Auckland's most picturesque bush settings.</p>
+          <p>Once again, you can also join our world-class speakers and an exclusive gathering of your Codemania family for the whole weekend after Codemania conference. <a href="/agenda.html#codemania-conversations" class="hilite">Codemania conversations</a> returns to the Waitakere Estate, deep in the heart of one of Auckland's most picturesque bush settings.</p>
         </div>
         <div class="about-text-column">
           <p>Like always, Codemania is an inclusive, safe space for all to enjoy. Please have a read of our <a class="hilite" href="/code-of-conduct.html">Code of Conduct</a>.</p>


### PR DESCRIPTION
This was pointing at a dedicated conversations page, which had incorrect dates. Looks like the relevant and updated content is now merged into the main Agenda page.